### PR TITLE
Create new postgres function and trigger for publishing message events

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ Widget build(BuildContext context) {
 }
 ```
 
+## Listing for Message Events
+
+Messages that are sent have corresponding `pg_notify` events that are triggered on the `chat_push_notification` channel. This can be listened to by a worker (ie a Supabase Edge Function) to perform a task, like sending a push notification.
+
+Using a PostgreSQL client like `psql`, you can listen for all message events by using:
+
+```
+LISTEN chat_push_notification;
+```
+
 ## RLS (Row level security)
 
 The preparation script automatically configures the security rules on the database tables and storage buckets, below is a summary of the rules that are applied:

--- a/example/utils/sql/02_database_trigger.sql
+++ b/example/utils/sql/02_database_trigger.sql
@@ -53,3 +53,38 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER update_status_before_insert
     BEFORE INSERT ON chats.messages
     FOR EACH ROW EXECUTE FUNCTION set_message_status_to_sent();
+
+CREATE OR REPLACE FUNCTION chats.send_push_notification()
+    RETURNS TRIGGER AS $$
+DECLARE
+    user_record RECORD;
+BEGIN
+    -- Loop through all users in the room except the author
+    FOR user_record IN
+        SELECT u.id, 
+               CASE WHEN u."lastSeen" >= (EXTRACT(epoch FROM NOW()) * 1000 - 30000) THEN true ELSE false END AS online
+        FROM chats.users u
+        JOIN chats.rooms r ON r.id = NEW."roomId"
+        WHERE u.id = ANY(r."userIds")
+          AND u.id <> NEW."authorId"
+    LOOP
+        -- If the user is not online, send a push notification
+        IF NOT user_record.online THEN
+            PERFORM pg_notify('chat_push_notification', 
+                json_build_object(
+                    'text', NEW.text,
+                    'author_id', NEW."authorId",
+                    'user_id', user_record.id
+                )::text);
+        END IF;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE TRIGGER send_push_notification_trigger
+    AFTER INSERT ON chats.messages
+    FOR EACH ROW
+    EXECUTE FUNCTION chats.send_push_notification();

--- a/example/utils/sql/02_database_trigger.sql
+++ b/example/utils/sql/02_database_trigger.sql
@@ -74,7 +74,8 @@ BEGIN
                 json_build_object(
                     'text', NEW.text,
                     'author_id', NEW."authorId",
-                    'user_id', user_record.id
+                    'user_id', user_record.id,
+                    'room_id', NEW."roomId"
                 )::text);
         END IF;
     END LOOP;


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged.

Please ensure you read through the Contributing Guide: https://github.com/insideapp-srl/flutter_supabase_chat_core/blob/main/CONTRIBUTING.md
-->

### What does it do?

Added a new postgres function `chats.send_push_notification()` and trigger to publishes events to `pg_notify` so that listeners (ie, supabase edge functions) can respond (ie sending a push notification to a user or device). It sends an event for each user that is in a room except the author. 

### Why is it needed?

I need to implement offline notifications for the app I am building. I could use a background listener on my app to listen for events on the messages table, however this doesn't work if the app is closed or suspended in the background.

### How to test it?

1. Apply the migration
2. Create a listener on the `chat_push_notification` postgres channel
3. Send a message
4. Observe that there are N-1 messages created on the channel, one for each of the members that wasn't the author. 

### Related issues/PRs

N/A